### PR TITLE
イベント登録画面で、カテゴリーとアーティストを選択できる機能を実装

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -63,6 +63,6 @@ class SchedulesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def schedule_params
-    params.require(:schedule).permit(:title, :description, :start_time, :end_time, :show_remaining_time).merge(category_id: 1, artist_id: 1)
+    params.require(:schedule).permit(:title, :description, :artist_id, :category_id, :start_time, :end_time, :show_remaining_time)
   end
 end

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -22,6 +22,16 @@
   </div>
 
   <div>
+    <%= form.label :Artist, style: "display: block" %>
+    <%= form.select :artist_id, Artist.all.collect { |c| [c.name, c.id] } %>
+  </div>
+
+  <div>
+    <%= form.label :Category, style: "display: block" %>
+    <%= form.select :category_id, Category.all.collect { |c| [c.name, c.id] } %>
+  </div>
+
+  <div>
     <%= form.label :start_time, style: "display: block" %>
     <%= form.datetime_field :start_time %>
   </div>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -10,6 +10,16 @@
   </p>
 
   <p>
+    <strong><%= I18n.t('activerecord.attributes.artist.name') %></strong>
+    <%= schedule.artist.name %>
+  </p>
+
+  <p>
+    <strong><%= I18n.t('activerecord.attributes.category.name') %></strong>
+    <%= schedule.category.name %>
+  </p>
+
+  <p>
     <strong><%= I18n.t('activerecord.attributes.schedule.start_time') %></strong>
     <%= schedule.start_time %>
   </p>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,3 +15,7 @@ ja:
         start_time: 開始時間
         end_time: 終了時間
         show_remaining_time: 通知しますか
+      artist:
+        name: アーティスト
+      category:
+        name: カテゴリー


### PR DESCRIPTION
ゴール：登録したカテゴリとアーティストを選択式で選び登録できる、一覧に表示される
- [x] Categoriesテーブルデータ作成
- [x] Artistsテーブルデータ作成
- [x] 登録フォームにカテゴリとアーティストを選択できるようにビューを修正
- [x] 一覧ページで表示できるようにビューを修正